### PR TITLE
feat: add catchers that serialize secret strings to [REDACTED]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "ferrous-llm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "ferrous-llm-anthropic"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "ferrous-llm-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -464,11 +464,11 @@ dependencies = [
 
 [[package]]
 name = "ferrous-llm-memory"
-version = "0.4.1"
+version = "0.5.0"
 
 [[package]]
 name = "ferrous-llm-ollama"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "ferrous-llm-openai"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 description = "LLM library"
 authors = ["Andre Roelofs <andre@eurora-labs.com>"]
 license = "Apache-2.0"
@@ -22,10 +22,10 @@ dotenv = "0.15"
 futures = "0.3"
 thiserror = "2.0.12"
 url = { version = "2.5.4" }
-ferrous-llm-core = { path = "./crates/ferrous-llm-core", version = "0.4.1" }
-ferrous-llm-ollama = { path = "./crates/ferrous-llm-ollama", version = "0.4.1" }
-ferrous-llm-anthropic = { path = "./crates/ferrous-llm-anthropic", version = "0.4.1" }
-ferrous-llm-openai = { path = "./crates/ferrous-llm-openai", version = "0.4.1" }
+ferrous-llm-core = { path = "./crates/ferrous-llm-core", version = "0.5.0" }
+ferrous-llm-ollama = { path = "./crates/ferrous-llm-ollama", version = "0.5.0" }
+ferrous-llm-anthropic = { path = "./crates/ferrous-llm-anthropic", version = "0.5.0" }
+ferrous-llm-openai = { path = "./crates/ferrous-llm-openai", version = "0.5.0" }
 
 [features]
 default = []
@@ -45,10 +45,10 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-ferrous-llm-core = { path = "./crates/ferrous-llm-core", version = "0.4.1" }
-ferrous-llm-openai = { path = "./crates/ferrous-llm-openai", version = "0.4.1", optional = true }
-ferrous-llm-ollama = { path = "./crates/ferrous-llm-ollama", version = "0.4.1", optional = true }
-ferrous-llm-anthropic = { path = "./crates/ferrous-llm-anthropic", version = "0.4.1", optional = true }
+ferrous-llm-core = { path = "./crates/ferrous-llm-core", version = "0.5.0" }
+ferrous-llm-openai = { path = "./crates/ferrous-llm-openai", version = "0.5.0", optional = true }
+ferrous-llm-ollama = { path = "./crates/ferrous-llm-ollama", version = "0.5.0", optional = true }
+ferrous-llm-anthropic = { path = "./crates/ferrous-llm-anthropic", version = "0.5.0", optional = true }
 dotenv.workspace = true
 tokio.workspace = true
 futures.workspace = true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add ferrous-llm to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ferrous-llm = "0.4.1"
+ferrous-llm = "0.5.0"
 ```
 
 ### Feature Flags
@@ -33,7 +33,7 @@ By default, no providers are enabled. Enable the providers you need:
 
 ```toml
 [dependencies]
-ferrous-llm = { version = "0.4.1", features = ["openai", "anthropic", "ollama"] }
+ferrous-llm = { version = "0.5.0", features = ["openai", "anthropic", "ollama"] }
 ```
 
 Available features:

--- a/crates/ferrous-llm-anthropic/Cargo.toml
+++ b/crates/ferrous-llm-anthropic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrous-llm-anthropic"
-version = "0.4.1"
+version = "0.5.0"
 description = "Anthropic provider for the LLM library"
 authors.workspace = true
 edition.workspace = true

--- a/crates/ferrous-llm-core/Cargo.toml
+++ b/crates/ferrous-llm-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrous-llm-core"
-version = "0.4.1"
+version = "0.5.0"
 description = "Core LLM library"
 authors.workspace = true
 edition.workspace = true

--- a/crates/ferrous-llm-core/src/config.rs
+++ b/crates/ferrous-llm-core/src/config.rs
@@ -32,8 +32,8 @@ pub trait ProviderConfig: Clone + Debug + Send + Sync {
 /// A secure string type for sensitive configuration values like API keys.
 ///
 /// This type ensures that sensitive values are not accidentally logged
-/// or displayed in debug output. It also prevents serialization to avoid
-/// accidentally exposing secrets in configuration files or logs.
+/// or displayed in debug output. It also redacts the value during serialization
+/// to avoid accidentally exposing secrets in configuration files or logs.
 #[derive(Clone, Deserialize)]
 pub struct SecretString(String);
 

--- a/crates/ferrous-llm-core/src/config.rs
+++ b/crates/ferrous-llm-core/src/config.rs
@@ -4,7 +4,7 @@
 //! use to manage their settings, validation, and initialization.
 
 use crate::error::ConfigError;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use std::fmt::Debug;
 use std::time::Duration;
 
@@ -32,8 +32,9 @@ pub trait ProviderConfig: Clone + Debug + Send + Sync {
 /// A secure string type for sensitive configuration values like API keys.
 ///
 /// This type ensures that sensitive values are not accidentally logged
-/// or displayed in debug output.
-#[derive(Clone, Serialize, Deserialize)]
+/// or displayed in debug output. It also prevents serialization to avoid
+/// accidentally exposing secrets in configuration files or logs.
+#[derive(Clone, Deserialize)]
 pub struct SecretString(String);
 
 impl SecretString {
@@ -77,6 +78,15 @@ impl From<&str> for SecretString {
 impl Debug for SecretString {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("[REDACTED]")
+    }
+}
+
+impl Serialize for SecretString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str("[REDACTED]")
     }
 }
 

--- a/crates/ferrous-llm-ollama/Cargo.toml
+++ b/crates/ferrous-llm-ollama/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrous-llm-ollama"
-version = "0.4.1"
+version = "0.5.0"
 description = "Ollama provider for the LLM library"
 authors.workspace = true
 edition.workspace = true

--- a/crates/ferrous-llm-openai/Cargo.toml
+++ b/crates/ferrous-llm-openai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ferrous-llm-openai"
-version = "0.4.1"
+version = "0.5.0"
 description = "OpenAI provider for the LLM library"
 authors.workspace = true
 edition.workspace = true

--- a/crates/ferrous-llm-openai/src/config.rs
+++ b/crates/ferrous-llm-openai/src/config.rs
@@ -281,4 +281,69 @@ mod tests {
             "https://custom.openai.com/v1/chat/completions"
         );
     }
+
+    #[test]
+    fn test_api_key_serialization_redaction() {
+        let config = OpenAIConfig::new("sk-1234567890abcdef1234567890abcdef", "gpt-4");
+
+        // Test JSON serialization
+        let serialized = serde_json::to_string(&config).expect("Failed to serialize config");
+
+        // Parse the JSON to check the api_key field
+        let json_value: serde_json::Value =
+            serde_json::from_str(&serialized).expect("Failed to parse JSON");
+        let api_key_value = json_value.get("api_key").expect("api_key field not found");
+
+        // Verify that the api_key is redacted in serialization
+        assert_eq!(api_key_value, "[REDACTED]");
+        assert_ne!(api_key_value, "sk-1234567890abcdef1234567890abcdef");
+
+        // Verify that we can still access the actual key via expose_secret
+        assert_eq!(
+            config.api_key.expose_secret(),
+            "sk-1234567890abcdef1234567890abcdef"
+        );
+    }
+
+    #[test]
+    fn test_config_debug_redaction() {
+        let config = OpenAIConfig::new("sk-supersecrettestkey123", "gpt-4");
+
+        // Test debug formatting
+        let debug_output = format!("{:?}", config);
+
+        // Verify that the debug output contains [REDACTED] for the API key
+        assert!(debug_output.contains("[REDACTED]"));
+        assert!(!debug_output.contains("sk-supersecrettestkey123"));
+
+        // Verify that other fields are still visible
+        assert!(debug_output.contains("gpt-4"));
+        assert!(debug_output.contains("api_key"));
+    }
+
+    #[test]
+    fn test_secret_string_serialization_various_keys() {
+        // Test with different API key formats
+        let test_keys = vec![
+            "sk-1234567890abcdef1234567890abcdef",
+            "sk-proj-1234567890abcdef1234567890abcdef",
+            "sk-org-1234567890abcdef1234567890abcdef",
+            "sk-short",
+        ];
+
+        for test_key in test_keys {
+            let config = OpenAIConfig::new(test_key, "gpt-4");
+            let serialized = serde_json::to_string(&config).expect("Failed to serialize config");
+            let json_value: serde_json::Value =
+                serde_json::from_str(&serialized).expect("Failed to parse JSON");
+            let api_key_value = json_value.get("api_key").expect("api_key field not found");
+
+            // All should be redacted
+            assert_eq!(api_key_value, "[REDACTED]");
+            assert_ne!(api_key_value, test_key);
+
+            // But we can still access the original
+            assert_eq!(config.api_key.expose_secret(), test_key);
+        }
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Secrets are now automatically redacted as “[REDACTED]” in JSON serialization and debug output, reducing risk of accidental exposure. Internal behavior remains unchanged.
- Documentation
  - Clarified how secret values are handled and redacted during serialization and debugging.
- Tests
  - Added comprehensive tests to verify redaction in serialization and debug output across various secret formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->